### PR TITLE
support both AMD + ES6 modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "6"
-  - "stable"
+  - "7"
 
 cache:
   yarn: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,9 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.12"
+    - nodejs_version: "4"
+    - nodejs_version: "6"
+    - nodejs_version: "7"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -53,16 +53,15 @@
     "walk-sync": "^0.3.1"
   },
   "dependencies": {
-    "amd-name-resolver": "^0.0.6",
     "broccoli-plugin": "^1.3.0",
     "exists-sync": "^0.0.4",
     "fs-tree-diff": "^0.5.2",
     "heimdalljs": "^0.2.1",
     "heimdalljs-logger": "^0.1.7",
     "mkdirp": "^0.5.1",
+    "mr-dep-walk": "^1.0.1",
     "path-posix": "^1.0.0",
     "rimraf": "^2.5.4",
-    "rollup": "^0.36.4",
     "symlink-or-copy": "^1.1.8"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -297,5 +297,5 @@ describe('BroccoliDependencyFunnel', function() {
         expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
       });
     });
-  })
+  });
 });

--- a/tests/index.js
+++ b/tests/index.js
@@ -39,10 +39,8 @@ describe('BroccoliDependencyFunnel', function() {
 
   const input = 'tmp/fixture-input';
   let node, pipeline;
-
-  beforeEach(function() {
-    fs.mkdirpSync(input);
-    fixture.writeSync(input, {
+  const FIXTURES = [
+    {
       'routes.js': 'import buildRoutes from "ember-engines/routes";import foo from "utils/foo";',
       'utils': {
         'foo.js': 'import derp from "./derp";export default {};',
@@ -50,240 +48,254 @@ describe('BroccoliDependencyFunnel', function() {
         'herp.js': 'export default {};'
       },
       'engine.js': 'import herp from "./utils/herp";'
-    });
-  });
+    },
 
-  afterEach(function() {
-    fs.removeSync(input);
-    return pipeline.cleanup().then(function() {
-      node = undefined;
-      pipeline = undefined;
-    });
-  });
+    {
+      'routes.js': `define('routes', ["ember-engines/routes", "utils/foo" ], function() { });`,
+      'utils': {
+        'foo.js': `define('foo', ['./derp'], function() { });`,
+        'derp.js': `define('derp', [], function() { });`,
+        'herp.js': `define('herp', [], function() { });`
+      },
+      'engine.js': `define('engine', ['./utils/herp'], function() { });`
+    }
+  ];
 
-  describe("build", function() {
-    it('returns a tree of the dependency graph when using include', async function() {
-      node = new BroccoliDependencyFunnel(input, {
-        include: true,
-        entry: 'routes.js',
-        external: [ 'ember-engines/routes' ]
-      });
-
-      pipeline = new broccoli.Builder(node);
-
-      const { directory } = await pipeline.build();
-
-      const output = walkSync(directory);
-      expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
+  FIXTURES.forEach(FIXTURE => {
+    beforeEach(function() {
+      fs.mkdirpSync(input);
+      fixture.writeSync(input, FIXTURE);
     });
 
-    it('returns a tree excluding the dependency graph when using exclude', async function() {
-      node = new BroccoliDependencyFunnel(input, {
-        exclude: true,
-        entry: 'routes.js',
-        external: [ 'ember-engines/routes' ]
-      });
-
-      pipeline = new broccoli.Builder(node);
-
-      const { directory } = await pipeline.build();
-
-      const output = walkSync(directory);
-      expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/herp.js' ]);
+    afterEach(function() {
+      fs.removeSync(input);
+      return pipeline.cleanup();
     });
 
-    it('returns an empty tree when entry does not exist and using include', async function() {
-      node = new BroccoliDependencyFunnel(input, {
-        include: true,
-        entry: 'does-not-exist.js',
-        external: [ 'ember-engines/routes' ]
+    describe("build", function() {
+      it('returns a tree of the dependency graph when using include', async function() {
+        node = new BroccoliDependencyFunnel(input, {
+          include: true,
+          entry: 'routes.js',
+          external: [ 'ember-engines/routes' ]
+        });
+
+        pipeline = new broccoli.Builder(node);
+
+        const { directory } = await pipeline.build();
+
+        const output = walkSync(directory);
+        expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
       });
 
-      pipeline = new broccoli.Builder(node);
+      it('returns a tree excluding the dependency graph when using exclude', async function() {
+        node = new BroccoliDependencyFunnel(input, {
+          exclude: true,
+          entry: 'routes.js',
+          external: [ 'ember-engines/routes' ]
+        });
 
-      const { directory } = await pipeline.build();
+        pipeline = new broccoli.Builder(node);
 
-      const output = walkSync(directory);
-      expect(output).to.deep.equal([]);
+        const { directory } = await pipeline.build();
+
+        const output = walkSync(directory);
+        expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/herp.js' ]);
+      });
+
+      it('returns an empty tree when entry does not exist and using include', async function() {
+        node = new BroccoliDependencyFunnel(input, {
+          include: true,
+          entry: 'does-not-exist.js',
+          external: [ 'ember-engines/routes' ]
+        });
+
+        pipeline = new broccoli.Builder(node);
+
+        const { directory } = await pipeline.build();
+
+        const output = walkSync(directory);
+        expect(output).to.deep.equal([]);
+      });
+
+      it('returns the input tree when entry does not exist and using exclude', async function() {
+        node = new BroccoliDependencyFunnel(input, {
+          exclude: true,
+          entry: 'does-not-exist.js',
+          external: [ 'ember-engines/routes' ]
+        });
+
+        pipeline = new broccoli.Builder(node);
+
+        const { directory } = await pipeline.build();
+
+        const output = walkSync(directory);
+        expect(output).to.deep.equal(walkSync(input));
+      });
     });
 
-    it('returns the input tree when entry does not exist and using exclude', async function() {
-      node = new BroccoliDependencyFunnel(input, {
-        exclude: true,
-        entry: 'does-not-exist.js',
-        external: [ 'ember-engines/routes' ]
+    describe('rebuild', function() {
+      it('is stable on unchanged rebuild with include', async function() {
+        node = new BroccoliDependencyFunnel(input, {
+          include: true,
+          entry: 'routes.js',
+          external: [ 'ember-engines/routes' ]
+        });
+
+        pipeline = new broccoli.Builder(node);
+
+        const { directory } = await pipeline.build();
+
+        const beforeStat = fs.statSync(directory);
+
+        await fsTick();
+        await pipeline.build();
+
+        const afterStat = fs.statSync(directory);
+        assertStatEqual(beforeStat, afterStat);
       });
 
-      pipeline = new broccoli.Builder(node);
+      it('is stable on unchanged rebuild with exclude', async function() {
+        node = new BroccoliDependencyFunnel(input, {
+          exclude: true,
+          entry: 'routes.js',
+          external: [ 'ember-engines/routes' ]
+        });
 
-      const { directory } = await pipeline.build();
+        pipeline = new broccoli.Builder(node);
 
-      const output = walkSync(directory);
-      expect(output).to.deep.equal(walkSync(input));
+        const { directory } = await pipeline.build();
+
+        const beforeStat = fs.statSync(directory);
+
+        await fsTick();
+        await pipeline.build();
+
+        const afterStat = fs.statSync(directory);
+        assertStatEqual(beforeStat, afterStat);
+      });
+
+      it('is stable when changes occur outside dep graph and using include', async function() {
+        node = new BroccoliDependencyFunnel(input, {
+          include: true,
+          entry: 'routes.js',
+          external: [ 'ember-engines/routes' ]
+        });
+
+        pipeline = new broccoli.Builder(node);
+        const { directory } = await pipeline.build();
+
+        const beforeStat = fs.statSync(directory);
+        await fsTick();
+
+        fixture.writeSync(input, {
+          'engine.js': ''
+        });
+
+        await pipeline.build();
+
+        const afterStat = fs.statSync(directory);
+        assertStatEqual(beforeStat, afterStat, 'stable rebuild when modifying file NOT in dep graph');
+      });
+
+      it('updates when changes occur in dep graph and using include', async function() {
+        node = new BroccoliDependencyFunnel(input, {
+          include: true,
+          entry: 'routes.js',
+          external: [ 'ember-engines/routes' ]
+        });
+
+        pipeline = new broccoli.Builder(node);
+        const { directory } = await pipeline.build();
+
+        const beforeStat = fs.statSync(directory);
+
+        let output = walkSync(directory);
+        expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
+
+        await fsTick();
+
+        fixture.writeSync(input, {
+          'routes.js': 'import herp from "utils/herp";'
+        });
+
+        await pipeline.build();
+
+        const afterStat = fs.statSync(directory);
+        assertStatChange(beforeStat, afterStat, 'instable rebuild when modifying file in dep graph');
+
+        output = walkSync(directory);
+        expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/herp.js' ]);
+      });
+
+      it('updates when changes occur outside dep graph and using exclude', async function() {
+        node = new BroccoliDependencyFunnel(input, {
+          exclude: true,
+          entry: 'routes.js',
+          external: [ 'ember-engines/routes' ]
+        });
+
+        pipeline = new broccoli.Builder(node);
+        const { directory } = await pipeline.build();
+
+        const engineStat = fs.statSync(directory + '/engine.js');
+        const routesStat = fs.statSync(directory + '/utils/herp.js');
+
+        await fsTick();
+
+        fixture.writeSync(input, {
+          'engine.js': ''
+        });
+
+        await pipeline.build();
+
+        const engineRebuildStat = fs.statSync(directory + '/engine.js');
+        assertStatChange(engineStat, engineRebuildStat, 'engine.js changed');
+
+        let routesRebuildStat = fs.statSync(directory + '/utils/herp.js');
+        assertStatEqual(routesStat, routesRebuildStat, 'routes.js unchanged');
+
+        await fsTick();
+
+        fs.unlink(path.join(input, 'engine.js'));
+
+        await pipeline.build();
+
+        expect(file(directory + '/engine.js')).to.not.exist;
+
+        routesRebuildStat = fs.statSync(directory + '/utils/herp.js');
+        assertStatEqual(routesStat, routesRebuildStat, 'routes.js unchanged second time');
+      });
+
+      it('updates when changes occur in dep graph and using exclude', async function() {
+        node = new BroccoliDependencyFunnel(input, {
+          exclude: true,
+          entry: 'routes.js',
+          external: [ 'ember-engines/routes' ]
+        });
+
+        pipeline = new broccoli.Builder(node);
+        const { directory } = await pipeline.build();
+
+        const buildStat = fs.statSync(directory);
+
+        let output = walkSync(directory);
+        expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/herp.js' ]);
+
+        await fsTick();
+
+        fixture.writeSync(input, {
+          'routes.js': 'import herp from "utils/herp";'
+        });
+
+        await pipeline.build();
+
+        const rebuildStat = fs.statSync(directory);
+        assertStatChange(rebuildStat, buildStat, 'instable rebuild when modifying file in dep graph');
+
+        output = walkSync(directory);
+        expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
+      });
     });
-  });
-
-  describe('rebuild', function() {
-    it('is stable on unchanged rebuild with include', async function() {
-      node = new BroccoliDependencyFunnel(input, {
-        include: true,
-        entry: 'routes.js',
-        external: [ 'ember-engines/routes' ]
-      });
-
-      pipeline = new broccoli.Builder(node);
-
-      const { directory } = await pipeline.build();
-
-      const beforeStat = fs.statSync(directory);
-
-      await fsTick();
-      await pipeline.build();
-
-      const afterStat = fs.statSync(directory);
-      assertStatEqual(beforeStat, afterStat);
-    });
-
-    it('is stable on unchanged rebuild with exclude', async function() {
-      node = new BroccoliDependencyFunnel(input, {
-        exclude: true,
-        entry: 'routes.js',
-        external: [ 'ember-engines/routes' ]
-      });
-
-      pipeline = new broccoli.Builder(node);
-
-      const { directory } = await pipeline.build();
-
-      const beforeStat = fs.statSync(directory);
-
-      await fsTick();
-      await pipeline.build();
-
-      const afterStat = fs.statSync(directory);
-      assertStatEqual(beforeStat, afterStat);
-    });
-
-    it('is stable when changes occur outside dep graph and using include', async function() {
-      node = new BroccoliDependencyFunnel(input, {
-        include: true,
-        entry: 'routes.js',
-        external: [ 'ember-engines/routes' ]
-      });
-
-      pipeline = new broccoli.Builder(node);
-      const { directory } = await pipeline.build();
-
-      const beforeStat = fs.statSync(directory);
-      await fsTick();
-
-      fixture.writeSync(input, {
-        'engine.js': ''
-      });
-
-      await pipeline.build();
-
-      const afterStat = fs.statSync(directory);
-      assertStatEqual(beforeStat, afterStat, 'stable rebuild when modifying file NOT in dep graph');
-    });
-
-    it('updates when changes occur in dep graph and using include', async function() {
-      node = new BroccoliDependencyFunnel(input, {
-        include: true,
-        entry: 'routes.js',
-        external: [ 'ember-engines/routes' ]
-      });
-
-      pipeline = new broccoli.Builder(node);
-      const { directory } = await pipeline.build();
-
-      const beforeStat = fs.statSync(directory);
-
-      let output = walkSync(directory);
-      expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
-
-      await fsTick();
-
-      fixture.writeSync(input, {
-        'routes.js': 'import herp from "utils/herp";'
-      });
-
-      await pipeline.build();
-
-      const afterStat = fs.statSync(directory);
-      assertStatChange(beforeStat, afterStat, 'instable rebuild when modifying file in dep graph');
-
-      output = walkSync(directory);
-      expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/herp.js' ]);
-    });
-
-    it('updates when changes occur outside dep graph and using exclude', async function() {
-      node = new BroccoliDependencyFunnel(input, {
-        exclude: true,
-        entry: 'routes.js',
-        external: [ 'ember-engines/routes' ]
-      });
-
-      pipeline = new broccoli.Builder(node);
-      const { directory } = await pipeline.build();
-
-      const engineStat = fs.statSync(directory + '/engine.js');
-      const routesStat = fs.statSync(directory + '/utils/herp.js');
-
-      await fsTick();
-
-      fixture.writeSync(input, {
-        'engine.js': ''
-      });
-
-      await pipeline.build();
-
-      const engineRebuildStat = fs.statSync(directory + '/engine.js');
-      assertStatChange(engineStat, engineRebuildStat, 'engine.js changed');
-
-      let routesRebuildStat = fs.statSync(directory + '/utils/herp.js');
-      assertStatEqual(routesStat, routesRebuildStat, 'routes.js unchanged');
-
-      await fsTick();
-
-      fs.unlink(path.join(input, 'engine.js'));
-
-      await pipeline.build();
-
-      expect(file(directory + '/engine.js')).to.not.exist;
-
-      routesRebuildStat = fs.statSync(directory + '/utils/herp.js');
-      assertStatEqual(routesStat, routesRebuildStat, 'routes.js unchanged second time');
-    });
-
-    it('updates when changes occur in dep graph and using exclude', async function() {
-      node = new BroccoliDependencyFunnel(input, {
-        exclude: true,
-        entry: 'routes.js',
-        external: [ 'ember-engines/routes' ]
-      });
-
-      pipeline = new broccoli.Builder(node);
-      const { directory } = await pipeline.build();
-
-      const buildStat = fs.statSync(directory);
-
-      let output = walkSync(directory);
-      expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/herp.js' ]);
-
-      await fsTick();
-
-      fixture.writeSync(input, {
-        'routes.js': 'import herp from "utils/herp";'
-      });
-
-      await pipeline.build();
-
-      const rebuildStat = fs.statSync(directory);
-      assertStatChange(rebuildStat, buildStat, 'instable rebuild when modifying file in dep graph');
-
-      output = walkSync(directory);
-      expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
-    });
-  });
+  })
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,10 @@ acorn@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.3.tgz#1a3e850b428e73ba6b09d1cc527f5aaad4d03ef1"
 
+acorn@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
+
 after@0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.1.tgz#ab5d4fb883f596816d3515f8f791c0af486dd627"
@@ -430,16 +434,7 @@ broccoli-persistent-filter@^1.0.1, broccoli-persistent-filter@^1.1.6, broccoli-p
     symlink-or-copy "^1.0.1"
     walk-sync "^0.3.1"
 
-broccoli-plugin@^1.0.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.2.2.tgz#0ed4320c20344487d0a2afafb963d52ee5179ab0"
-  dependencies:
-    promise-map-series "^0.2.1"
-    quick-temp "^0.1.3"
-    rimraf "^2.3.4"
-    symlink-or-copy "^1.0.1"
-
-broccoli-plugin@^1.3.0:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#bee704a8e42da08cb58e513aaa436efb7f0ef1ee"
   dependencies:
@@ -945,11 +940,11 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@1.0.2, escape-string-regexp@^1.0.2:
+escape-string-regexp@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
-escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -1872,6 +1867,12 @@ mocha@^2.5.3:
     mkdirp "0.5.1"
     supports-color "1.2.0"
     to-iso-string "0.0.2"
+
+mr-dep-walk@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/mr-dep-walk/-/mr-dep-walk-1.0.0.tgz#febad5eb7a41afbe9b5b6c29990d9c7445f63674"
+  dependencies:
+    acorn "^4.0.4"
 
 ms@0.7.1:
   version "0.7.1"


### PR DESCRIPTION
cc @rwjblue. This may help you \w what we chatted about before you went to sleep.

* duplicated the tests to handle both AMD + ES6 variants.
* https://github.com/stefanpenner/mr-dep-walk is what handles the parsing and stuff
* if we need it to have a persistent-cache https://github.com/stefanpenner/mr-dep-walk/pull/1 is a starting point (but needs measuring/tuning)

---

I still think we should push all this work up to the baseline babel transpilers (e.g. they should just give us a dep graph we can process later). But regardless, this may be a handy interim step.