### PR TITLE
Add tests for external modules being imported.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "heimdalljs": "^0.2.1",
     "heimdalljs-logger": "^0.1.7",
     "mkdirp": "^0.5.1",
-    "mr-dep-walk": "^1.0.1",
+    "mr-dep-walk": "^1.1.1",
     "path-posix": "^1.0.0",
     "rimraf": "^2.5.4",
     "symlink-or-copy": "^1.1.8"

--- a/src/utils/copy-file.js
+++ b/src/utils/copy-file.js
@@ -16,6 +16,12 @@ export default function copyFile(sourcePath, destPath) {
   try {
     symlinkOrCopy.sync(sourcePath, destPath);
   } catch(e) {
+    // TODO: change mr-dep-walk API to expose found vs missing (aka external) deps
+    // if sourcePath does not exist, do nothing
+    if (!existsSync(sourcePath)) {
+      return;
+    }
+
     // If it failed, make sure the directory exists
     if (!existsSync(destDir)) {
       mkdirp.sync(destDir);

--- a/tests/index.js
+++ b/tests/index.js
@@ -41,7 +41,11 @@ describe('BroccoliDependencyFunnel', function() {
   let node, pipeline;
   const FIXTURES = [
     {
-      'routes.js': 'import buildRoutes from "ember-engines/routes";import foo from "utils/foo";',
+      'routes.js': `
+        import buildRoutes from "ember-engines/routes";
+        import foo from "utils/foo";
+        import bar from "some-external/thing";
+      `,
       'utils': {
         'foo.js': 'import derp from "./derp";export default {};',
         'derp.js': 'export default {};',
@@ -51,7 +55,7 @@ describe('BroccoliDependencyFunnel', function() {
     },
 
     {
-      'routes.js': `define('routes', ["ember-engines/routes", "utils/foo" ], function() { });`,
+      'routes.js': `define('routes', ["ember-engines/routes", "utils/foo", "some-external/thing" ], function() { });`,
       'utils': {
         'foo.js': `define('foo', ['./derp'], function() { });`,
         'derp.js': `define('derp', [], function() { });`,
@@ -85,7 +89,7 @@ describe('BroccoliDependencyFunnel', function() {
         const { directory } = await pipeline.build();
 
         const output = walkSync(directory);
-        expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
+        expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/derp.js', 'utils/foo.js']);
       });
 
       it('returns a tree excluding the dependency graph when using exclude', async function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,11 +1868,12 @@ mocha@^2.5.3:
     supports-color "1.2.0"
     to-iso-string "0.0.2"
 
-mr-dep-walk@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/mr-dep-walk/-/mr-dep-walk-1.0.0.tgz#febad5eb7a41afbe9b5b6c29990d9c7445f63674"
+mr-dep-walk@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/mr-dep-walk/-/mr-dep-walk-1.1.1.tgz#7117ab4e737d2ac8e1768e406fc62ca04171986d"
   dependencies:
     acorn "^4.0.4"
+    amd-name-resolver "^0.0.6"
 
 ms@0.7.1:
   version "0.7.1"
@@ -2264,12 +2265,6 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
-rollup@^0.36.4:
-  version "0.36.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.36.4.tgz#a224494c5386c1d73d38f7bb86f69f5eb011a3d2"
-  dependencies:
-    source-map-support "^0.4.0"
-
 rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@~3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.2.1.tgz#07cb4a5df25add9e826ebc67dcc9fd89db27d84a"
@@ -2419,12 +2414,6 @@ source-map-support@^0.2.10:
   dependencies:
     source-map "0.1.32"
 
-source-map-support@^0.4.0:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.6.tgz#32552aa64b458392a85eab3b0b5ee61527167aeb"
-  dependencies:
-    source-map "^0.5.3"
-
 source-map@0.1.32:
   version "0.1.32"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.32.tgz#c8b6c167797ba4740a8ea33252162ff08591b266"
@@ -2437,7 +2426,7 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@~0.5.0, source-map@~0.5.1:
+source-map@^0.5.0, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 


### PR DESCRIPTION
This test emulates a situation where you might import something into your `addon/routes.js` from another addon that is assumed to be a dependency of the host app and is not listed in the engines specific dependencies. In that scenario the tree that we provide to broccoli-dependency-funnel would not include the module in question.

The prior implementation (via rollup) did not error in this scenario (it marked the missing module as "external" and carried on about its work). mr-dep-walk currently throws an error when this occurs.

This PR was originally a failing test for #20, but with the last commit bumps versions of mr-dep-walk to 1.1.1 which properly handles the case in question.