### PR TITLE
Fix tests to ensure all fixtures are used

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -41,264 +41,272 @@ describe('BroccoliDependencyFunnel', function() {
   let node, pipeline;
   const FIXTURES = [
     {
-      'routes.js': `
-        import buildRoutes from "ember-engines/routes";
-        import foo from "utils/foo";
-        import bar from "some-external/thing";
-      `,
-      'utils': {
-        'foo.js': 'import derp from "./derp";export default {};',
-        'derp.js': 'export default {};',
-        'herp.js': 'export default {};'
-      },
-      'engine.js': 'import herp from "./utils/herp";'
+      title: 'ES6',
+      data: {
+        'routes.js': `
+          import buildRoutes from "ember-engines/routes";
+          import foo from "utils/foo";
+          import bar from "some-external/thing";
+        `,
+        'utils': {
+          'foo.js': 'import derp from "./derp";export default {};',
+          'derp.js': 'export default {};',
+          'herp.js': 'export default {};'
+        },
+        'engine.js': 'import herp from "./utils/herp";'
+      }
     },
 
     {
-      'routes.js': `define('routes', ["ember-engines/routes", "utils/foo", "some-external/thing" ], function() { });`,
-      'utils': {
-        'foo.js': `define('foo', ['./derp'], function() { });`,
-        'derp.js': `define('derp', [], function() { });`,
-        'herp.js': `define('herp', [], function() { });`
-      },
-      'engine.js': `define('engine', ['./utils/herp'], function() { });`
+      title: 'ES5',
+      data: {
+        'routes.js': `define('routes', ["ember-engines/routes", "utils/foo", "some-external/thing" ], function() { });`,
+        'utils': {
+          'foo.js': `define('foo', ['./derp'], function() { });`,
+          'derp.js': `define('derp', [], function() { });`,
+          'herp.js': `define('herp', [], function() { });`
+        },
+        'engine.js': `define('engine', ['./utils/herp'], function() { });`
+      }
     }
   ];
 
   FIXTURES.forEach(FIXTURE => {
-    beforeEach(function() {
-      fs.mkdirpSync(input);
-      fixture.writeSync(input, FIXTURE);
-    });
-
-    afterEach(function() {
-      fs.removeSync(input);
-      return pipeline.cleanup();
-    });
-
-    describe("build", function() {
-      it('returns a tree of the dependency graph when using include', async function() {
-        node = new BroccoliDependencyFunnel(input, {
-          include: true,
-          entry: 'routes.js',
-          external: [ 'ember-engines/routes' ]
-        });
-
-        pipeline = new broccoli.Builder(node);
-
-        const { directory } = await pipeline.build();
-
-        const output = walkSync(directory);
-        expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/derp.js', 'utils/foo.js']);
+    describe(FIXTURE.title, function() {
+      beforeEach(function() {
+        fs.mkdirpSync(input);
+        fixture.writeSync(input, FIXTURE.data);
       });
 
-      it('returns a tree excluding the dependency graph when using exclude', async function() {
-        node = new BroccoliDependencyFunnel(input, {
-          exclude: true,
-          entry: 'routes.js',
-          external: [ 'ember-engines/routes' ]
-        });
-
-        pipeline = new broccoli.Builder(node);
-
-        const { directory } = await pipeline.build();
-
-        const output = walkSync(directory);
-        expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/herp.js' ]);
+      afterEach(function() {
+        fs.removeSync(input);
+        return pipeline.cleanup();
       });
 
-      it('returns an empty tree when entry does not exist and using include', async function() {
-        node = new BroccoliDependencyFunnel(input, {
-          include: true,
-          entry: 'does-not-exist.js',
-          external: [ 'ember-engines/routes' ]
+      describe("build", function() {
+        it('returns a tree of the dependency graph when using include', async function() {
+          node = new BroccoliDependencyFunnel(input, {
+            include: true,
+            entry: 'routes.js',
+            external: [ 'ember-engines/routes' ]
+          });
+
+          pipeline = new broccoli.Builder(node);
+
+          const { directory } = await pipeline.build();
+
+          const output = walkSync(directory);
+          expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/derp.js', 'utils/foo.js']);
         });
 
-        pipeline = new broccoli.Builder(node);
+        it('returns a tree excluding the dependency graph when using exclude', async function() {
+          node = new BroccoliDependencyFunnel(input, {
+            exclude: true,
+            entry: 'routes.js',
+            external: [ 'ember-engines/routes' ]
+          });
 
-        const { directory } = await pipeline.build();
+          pipeline = new broccoli.Builder(node);
 
-        const output = walkSync(directory);
-        expect(output).to.deep.equal([]);
+          const { directory } = await pipeline.build();
+
+          const output = walkSync(directory);
+          expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/herp.js' ]);
+        });
+
+        it('returns an empty tree when entry does not exist and using include', async function() {
+          node = new BroccoliDependencyFunnel(input, {
+            include: true,
+            entry: 'does-not-exist.js',
+            external: [ 'ember-engines/routes' ]
+          });
+
+          pipeline = new broccoli.Builder(node);
+
+          const { directory } = await pipeline.build();
+
+          const output = walkSync(directory);
+          expect(output).to.deep.equal([]);
+        });
+
+        it('returns the input tree when entry does not exist and using exclude', async function() {
+          node = new BroccoliDependencyFunnel(input, {
+            exclude: true,
+            entry: 'does-not-exist.js',
+            external: [ 'ember-engines/routes' ]
+          });
+
+          pipeline = new broccoli.Builder(node);
+
+          const { directory } = await pipeline.build();
+
+          const output = walkSync(directory);
+          expect(output).to.deep.equal(walkSync(input));
+        });
       });
 
-      it('returns the input tree when entry does not exist and using exclude', async function() {
-        node = new BroccoliDependencyFunnel(input, {
-          exclude: true,
-          entry: 'does-not-exist.js',
-          external: [ 'ember-engines/routes' ]
+      describe('rebuild', function() {
+        it('is stable on unchanged rebuild with include', async function() {
+          node = new BroccoliDependencyFunnel(input, {
+            include: true,
+            entry: 'routes.js',
+            external: [ 'ember-engines/routes' ]
+          });
+
+          pipeline = new broccoli.Builder(node);
+
+          const { directory } = await pipeline.build();
+
+          const beforeStat = fs.statSync(directory);
+
+          await fsTick();
+          await pipeline.build();
+
+          const afterStat = fs.statSync(directory);
+          assertStatEqual(beforeStat, afterStat);
         });
 
-        pipeline = new broccoli.Builder(node);
+        it('is stable on unchanged rebuild with exclude', async function() {
+          node = new BroccoliDependencyFunnel(input, {
+            exclude: true,
+            entry: 'routes.js',
+            external: [ 'ember-engines/routes' ]
+          });
 
-        const { directory } = await pipeline.build();
+          pipeline = new broccoli.Builder(node);
 
-        const output = walkSync(directory);
-        expect(output).to.deep.equal(walkSync(input));
-      });
-    });
+          const { directory } = await pipeline.build();
 
-    describe('rebuild', function() {
-      it('is stable on unchanged rebuild with include', async function() {
-        node = new BroccoliDependencyFunnel(input, {
-          include: true,
-          entry: 'routes.js',
-          external: [ 'ember-engines/routes' ]
+          const beforeStat = fs.statSync(directory);
+
+          await fsTick();
+          await pipeline.build();
+
+          const afterStat = fs.statSync(directory);
+          assertStatEqual(beforeStat, afterStat);
         });
 
-        pipeline = new broccoli.Builder(node);
+        it('is stable when changes occur outside dep graph and using include', async function() {
+          node = new BroccoliDependencyFunnel(input, {
+            include: true,
+            entry: 'routes.js',
+            external: [ 'ember-engines/routes' ]
+          });
 
-        const { directory } = await pipeline.build();
+          pipeline = new broccoli.Builder(node);
+          const { directory } = await pipeline.build();
 
-        const beforeStat = fs.statSync(directory);
+          const beforeStat = fs.statSync(directory);
+          await fsTick();
 
-        await fsTick();
-        await pipeline.build();
+          fixture.writeSync(input, {
+            'engine.js': ''
+          });
 
-        const afterStat = fs.statSync(directory);
-        assertStatEqual(beforeStat, afterStat);
-      });
+          await pipeline.build();
 
-      it('is stable on unchanged rebuild with exclude', async function() {
-        node = new BroccoliDependencyFunnel(input, {
-          exclude: true,
-          entry: 'routes.js',
-          external: [ 'ember-engines/routes' ]
+          const afterStat = fs.statSync(directory);
+          assertStatEqual(beforeStat, afterStat, 'stable rebuild when modifying file NOT in dep graph');
         });
 
-        pipeline = new broccoli.Builder(node);
+        it('updates when changes occur in dep graph and using include', async function() {
+          node = new BroccoliDependencyFunnel(input, {
+            include: true,
+            entry: 'routes.js',
+            external: [ 'ember-engines/routes' ]
+          });
 
-        const { directory } = await pipeline.build();
+          pipeline = new broccoli.Builder(node);
+          const { directory } = await pipeline.build();
 
-        const beforeStat = fs.statSync(directory);
+          const beforeStat = fs.statSync(directory);
 
-        await fsTick();
-        await pipeline.build();
+          let output = walkSync(directory);
+          expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
 
-        const afterStat = fs.statSync(directory);
-        assertStatEqual(beforeStat, afterStat);
-      });
+          await fsTick();
 
-      it('is stable when changes occur outside dep graph and using include', async function() {
-        node = new BroccoliDependencyFunnel(input, {
-          include: true,
-          entry: 'routes.js',
-          external: [ 'ember-engines/routes' ]
+          fixture.writeSync(input, {
+            'routes.js': 'import herp from "utils/herp";'
+          });
+
+          await pipeline.build();
+
+          const afterStat = fs.statSync(directory);
+          assertStatChange(beforeStat, afterStat, 'instable rebuild when modifying file in dep graph');
+
+          output = walkSync(directory);
+          expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/herp.js' ]);
         });
 
-        pipeline = new broccoli.Builder(node);
-        const { directory } = await pipeline.build();
+        it('updates when changes occur outside dep graph and using exclude', async function() {
+          node = new BroccoliDependencyFunnel(input, {
+            exclude: true,
+            entry: 'routes.js',
+            external: [ 'ember-engines/routes' ]
+          });
 
-        const beforeStat = fs.statSync(directory);
-        await fsTick();
+          pipeline = new broccoli.Builder(node);
+          const { directory } = await pipeline.build();
 
-        fixture.writeSync(input, {
-          'engine.js': ''
+          const engineStat = fs.statSync(directory + '/engine.js');
+          const routesStat = fs.statSync(directory + '/utils/herp.js');
+
+          await fsTick();
+
+          fixture.writeSync(input, {
+            'engine.js': ''
+          });
+
+          await pipeline.build();
+
+          const engineRebuildStat = fs.statSync(directory + '/engine.js');
+          assertStatChange(engineStat, engineRebuildStat, 'engine.js changed');
+
+          let routesRebuildStat = fs.statSync(directory + '/utils/herp.js');
+          assertStatEqual(routesStat, routesRebuildStat, 'routes.js unchanged');
+
+          await fsTick();
+
+          fs.unlink(path.join(input, 'engine.js'));
+
+          await pipeline.build();
+
+          expect(file(directory + '/engine.js')).to.not.exist;
+
+          routesRebuildStat = fs.statSync(directory + '/utils/herp.js');
+          assertStatEqual(routesStat, routesRebuildStat, 'routes.js unchanged second time');
         });
 
-        await pipeline.build();
+        it('updates when changes occur in dep graph and using exclude', async function() {
+          node = new BroccoliDependencyFunnel(input, {
+            exclude: true,
+            entry: 'routes.js',
+            external: [ 'ember-engines/routes' ]
+          });
 
-        const afterStat = fs.statSync(directory);
-        assertStatEqual(beforeStat, afterStat, 'stable rebuild when modifying file NOT in dep graph');
-      });
+          pipeline = new broccoli.Builder(node);
+          const { directory } = await pipeline.build();
 
-      it('updates when changes occur in dep graph and using include', async function() {
-        node = new BroccoliDependencyFunnel(input, {
-          include: true,
-          entry: 'routes.js',
-          external: [ 'ember-engines/routes' ]
+          const buildStat = fs.statSync(directory);
+
+          let output = walkSync(directory);
+          expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/herp.js' ]);
+
+          await fsTick();
+
+          fixture.writeSync(input, {
+            'routes.js': 'import herp from "utils/herp";'
+          });
+
+          await pipeline.build();
+
+          const rebuildStat = fs.statSync(directory);
+          assertStatChange(rebuildStat, buildStat, 'instable rebuild when modifying file in dep graph');
+
+          output = walkSync(directory);
+          expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
         });
-
-        pipeline = new broccoli.Builder(node);
-        const { directory } = await pipeline.build();
-
-        const beforeStat = fs.statSync(directory);
-
-        let output = walkSync(directory);
-        expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
-
-        await fsTick();
-
-        fixture.writeSync(input, {
-          'routes.js': 'import herp from "utils/herp";'
-        });
-
-        await pipeline.build();
-
-        const afterStat = fs.statSync(directory);
-        assertStatChange(beforeStat, afterStat, 'instable rebuild when modifying file in dep graph');
-
-        output = walkSync(directory);
-        expect(output).to.deep.equal([ 'routes.js', 'utils/', 'utils/herp.js' ]);
-      });
-
-      it('updates when changes occur outside dep graph and using exclude', async function() {
-        node = new BroccoliDependencyFunnel(input, {
-          exclude: true,
-          entry: 'routes.js',
-          external: [ 'ember-engines/routes' ]
-        });
-
-        pipeline = new broccoli.Builder(node);
-        const { directory } = await pipeline.build();
-
-        const engineStat = fs.statSync(directory + '/engine.js');
-        const routesStat = fs.statSync(directory + '/utils/herp.js');
-
-        await fsTick();
-
-        fixture.writeSync(input, {
-          'engine.js': ''
-        });
-
-        await pipeline.build();
-
-        const engineRebuildStat = fs.statSync(directory + '/engine.js');
-        assertStatChange(engineStat, engineRebuildStat, 'engine.js changed');
-
-        let routesRebuildStat = fs.statSync(directory + '/utils/herp.js');
-        assertStatEqual(routesStat, routesRebuildStat, 'routes.js unchanged');
-
-        await fsTick();
-
-        fs.unlink(path.join(input, 'engine.js'));
-
-        await pipeline.build();
-
-        expect(file(directory + '/engine.js')).to.not.exist;
-
-        routesRebuildStat = fs.statSync(directory + '/utils/herp.js');
-        assertStatEqual(routesStat, routesRebuildStat, 'routes.js unchanged second time');
-      });
-
-      it('updates when changes occur in dep graph and using exclude', async function() {
-        node = new BroccoliDependencyFunnel(input, {
-          exclude: true,
-          entry: 'routes.js',
-          external: [ 'ember-engines/routes' ]
-        });
-
-        pipeline = new broccoli.Builder(node);
-        const { directory } = await pipeline.build();
-
-        const buildStat = fs.statSync(directory);
-
-        let output = walkSync(directory);
-        expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/herp.js' ]);
-
-        await fsTick();
-
-        fixture.writeSync(input, {
-          'routes.js': 'import herp from "utils/herp";'
-        });
-
-        await pipeline.build();
-
-        const rebuildStat = fs.statSync(directory);
-        assertStatChange(rebuildStat, buildStat, 'instable rebuild when modifying file in dep graph');
-
-        output = walkSync(directory);
-        expect(output).to.deep.equal([ 'engine.js', 'utils/', 'utils/derp.js', 'utils/foo.js' ]);
       });
     });
   });


### PR DESCRIPTION
Pro tip: Include [`w=1`](https://github.com/ember-engines/broccoli-dependency-funnel/pull/22/files?w=1) as a query param when viewing the diff.